### PR TITLE
Fix dynamic player search

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ searchInput.addEventListener('input', function() {
 });
 
 function searchPlayers(query) {
-  fetch(`https://statsapi.mlb.com/api/v1/people/search?name=${encodeURIComponent(query)}&limit=10`)
+  fetch(`https://statsapi.mlb.com/api/v1/people/search?names=${encodeURIComponent(query)}&sportId=1&limit=10`)
     .then(response => response.json())
     .then(data => {
       resultsDiv.innerHTML = '';


### PR DESCRIPTION
## Summary
- fix autocomplete search by using the correct `names` parameter for MLB Stats API

## Testing
- `tidy -errors index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb2494bc0832ca168ff34c677d92e