### PR TITLE
Add year selection for player comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This simple web page lets you search for any baseball player by name and shows s
 
 ## Usage
 
-Open `index.html` in your browser. Type a player's name and you'll see autocomplete suggestions. Click a suggestion to fill in the input box.
+Open `index.html` in your browser. Type a player's name and you'll see autocomplete suggestions. Use the year box to set the season you're interested in. Once you click a suggestion the page will fetch that player's stats for the selected season and show the most similar qualified player from the same year.
 
 To serve locally (optional):
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 <body>
 <h1>Baseball Player Search</h1>
 <input type="text" id="search" placeholder="Type a player's name..." autocomplete="off" />
+<input type="number" id="year" placeholder="Year" min="1901" max="2023" value="2023" style="width:80px; margin-left:5px;" />
 <div id="results"></div>
 <div id="playerStats"></div>
 <script>
@@ -55,8 +56,9 @@ function searchPlayers(query) {
 }
 
 function fetchPlayerAndSimilar(id) {
+  const year = document.getElementById('year').value || '2023';
   statsDiv.textContent = 'Loading stats...';
-  fetch(`https://statsapi.mlb.com/api/v1/people/${id}?hydrate=stats(group=hitting,pitching,type=season,season=2023)`)
+  fetch(`https://statsapi.mlb.com/api/v1/people/${id}?hydrate=stats(group=hitting,pitching,type=season,season=${year})`)
     .then(r => r.json())
     .then(data => {
       const person = data.people[0];
@@ -65,7 +67,7 @@ function fetchPlayerAndSimilar(id) {
       const statsObj = person.stats.find(s => s.group.displayName.toLowerCase() === group);
       if (!statsObj || !statsObj.splits.length) throw new Error('No stats');
       const playerMetrics = computeMetrics(statsObj.splits[0].stat, isPitcher);
-      fetch(`https://statsapi.mlb.com/api/v1/stats?stats=season&group=${group}&season=2023&playerPool=qualified&limit=300`)
+      fetch(`https://statsapi.mlb.com/api/v1/stats?stats=season&group=${group}&season=${year}&playerPool=qualified&limit=300`)
         .then(r2 => r2.json())
         .then(allData => {
           let best;
@@ -77,7 +79,7 @@ function fetchPlayerAndSimilar(id) {
               best = { diff, player: split.player, metrics: m };
             }
           });
-          if (best) displayStats(person, playerMetrics, best);
+          if (best) displayStats(person, playerMetrics, best, year);
           else statsDiv.textContent = 'No similar player found.';
         });
     })
@@ -131,8 +133,8 @@ function similarity(a, b, isPitcher) {
   return sum;
 }
 
-function displayStats(player, metrics, best) {
-  let table = '<h2>Similarity Results</h2><table border="1" cellpadding="5"><tr><th>Stat</th><th>' + player.fullName + '</th><th>' + best.player.fullName + '</th></tr>';
+function displayStats(player, metrics, best, year) {
+  let table = `<h2>Similarity Results (${year})</h2><table border="1" cellpadding="5"><tr><th>Stat</th><th>${player.fullName}</th><th>${best.player.fullName}</th></tr>`;
   if (metrics.AVG !== undefined) {
     table += `<tr><td>AVG</td><td>${metrics.AVG}</td><td>${best.metrics.AVG}</td></tr>`;
     table += `<tr><td>WAR</td><td>${metrics.WAR}</td><td>${best.metrics.WAR}</td></tr>`;


### PR DESCRIPTION
## Summary
- allow choosing a season year before fetching stats
- fetch the chosen season for both the player and the comparison pool
- show the season year in the results table
- update README with instructions about the year box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fb9a760bc832cac8369d859b82296