### PR TITLE
Fix player stats fetch and handle missing WAR

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,13 +58,17 @@ function searchPlayers(query) {
 function fetchPlayerAndSimilar(id) {
   const year = document.getElementById('year').value || '2023';
   statsDiv.textContent = 'Loading stats...';
-  fetch(`https://statsapi.mlb.com/api/v1/people/${id}?hydrate=stats(group=hitting,pitching,type=season,season=${year})`)
+  fetch(`https://statsapi.mlb.com/api/v1/people/${id}`)
     .then(r => r.json())
     .then(data => {
       const person = data.people[0];
       const isPitcher = person.primaryPosition && person.primaryPosition.abbreviation === 'P';
       const group = isPitcher ? 'pitching' : 'hitting';
-      const statsObj = person.stats.find(s => s.group.displayName.toLowerCase() === group);
+      return fetch(`https://statsapi.mlb.com/api/v1/people/${id}/stats?stats=season&group=${group}&season=${year}`)
+        .then(r2 => r2.json())
+        .then(statsData => ({ person, isPitcher, group, statsObj: statsData.stats[0] }));
+    })
+    .then(({ person, isPitcher, group, statsObj }) => {
       if (!statsObj || !statsObj.splits.length) throw new Error('No stats');
       const playerMetrics = computeMetrics(statsObj.splits[0].stat, isPitcher);
       fetch(`https://statsapi.mlb.com/api/v1/stats?stats=season&group=${group}&season=${year}&playerPool=qualified&limit=300`)
@@ -83,10 +87,17 @@ function fetchPlayerAndSimilar(id) {
           else statsDiv.textContent = 'No similar player found.';
         });
     })
-    .catch(err => {
-      statsDiv.textContent = 'Error loading stats.';
-      console.error(err);
-    });
+  .catch(err => {
+    statsDiv.textContent = 'Error loading stats.';
+    console.error(err);
+  });
+}
+
+function parseWar(stat) {
+  const val = stat.war ?? stat.winsAboveReplacement;
+  if (val === undefined || val === null) return null;
+  const num = parseFloat(val);
+  return isNaN(num) ? null : num;
 }
 
 function computeMetrics(stat, isPitcher) {
@@ -96,7 +107,7 @@ function computeMetrics(stat, isPitcher) {
     const soRate = bf ? (Number(stat.strikeOuts) / bf) * 100 : 0;
     return {
       ERA: parseFloat(stat.era),
-      WAR: parseFloat(stat.winsAboveReplacement || 0),
+      WAR: parseWar(stat),
       BBp: bbRate,
       SOp: soRate
     };
@@ -106,7 +117,7 @@ function computeMetrics(stat, isPitcher) {
     const kRate = pa ? (Number(stat.strikeOuts) / pa) * 100 : 0;
     return {
       AVG: parseFloat(stat.avg),
-      WAR: parseFloat(stat.winsAboveReplacement || 0),
+      WAR: parseWar(stat),
       OBP: parseFloat(stat.obp),
       OPS: parseFloat(stat.ops),
       BBp: bbRate,
@@ -119,12 +130,12 @@ function similarity(a, b, isPitcher) {
   let sum = 0;
   if (isPitcher) {
     sum += Math.abs(a.ERA - b.ERA);
-    sum += Math.abs(a.WAR - b.WAR);
+    if (a.WAR != null && b.WAR != null) sum += Math.abs(a.WAR - b.WAR);
     sum += Math.abs(a.BBp - b.BBp);
     sum += Math.abs(a.SOp - b.SOp);
   } else {
     sum += Math.abs(a.AVG - b.AVG);
-    sum += Math.abs(a.WAR - b.WAR);
+    if (a.WAR != null && b.WAR != null) sum += Math.abs(a.WAR - b.WAR);
     sum += Math.abs(a.OBP - b.OBP);
     sum += Math.abs(a.OPS - b.OPS);
     sum += Math.abs(a.BBp - b.BBp);
@@ -137,14 +148,14 @@ function displayStats(player, metrics, best, year) {
   let table = `<h2>Similarity Results (${year})</h2><table border="1" cellpadding="5"><tr><th>Stat</th><th>${player.fullName}</th><th>${best.player.fullName}</th></tr>`;
   if (metrics.AVG !== undefined) {
     table += `<tr><td>AVG</td><td>${metrics.AVG}</td><td>${best.metrics.AVG}</td></tr>`;
-    table += `<tr><td>WAR</td><td>${metrics.WAR}</td><td>${best.metrics.WAR}</td></tr>`;
+    table += `<tr><td>WAR</td><td>${metrics.WAR ?? 'N/A'}</td><td>${best.metrics.WAR ?? 'N/A'}</td></tr>`;
     table += `<tr><td>OBP</td><td>${metrics.OBP}</td><td>${best.metrics.OBP}</td></tr>`;
     table += `<tr><td>OPS</td><td>${metrics.OPS}</td><td>${best.metrics.OPS}</td></tr>`;
     table += `<tr><td>BB%</td><td>${metrics.BBp.toFixed(1)}</td><td>${best.metrics.BBp.toFixed(1)}</td></tr>`;
     table += `<tr><td>K%</td><td>${metrics.Kp.toFixed(1)}</td><td>${best.metrics.Kp.toFixed(1)}</td></tr>`;
   } else {
     table += `<tr><td>ERA</td><td>${metrics.ERA}</td><td>${best.metrics.ERA}</td></tr>`;
-    table += `<tr><td>WAR</td><td>${metrics.WAR}</td><td>${best.metrics.WAR}</td></tr>`;
+    table += `<tr><td>WAR</td><td>${metrics.WAR ?? 'N/A'}</td><td>${best.metrics.WAR ?? 'N/A'}</td></tr>`;
     table += `<tr><td>BB%</td><td>${metrics.BBp.toFixed(1)}</td><td>${best.metrics.BBp.toFixed(1)}</td></tr>`;
     table += `<tr><td>SO%</td><td>${metrics.SOp.toFixed(1)}</td><td>${best.metrics.SOp.toFixed(1)}</td></tr>`;
   }


### PR DESCRIPTION
## Summary
- ensure stats request uses correct group
- add helper to parse WAR gracefully
- ignore WAR in similarity if not available
- mark WAR as `N/A` when missing

## Testing
- `pre-commit` *(fails: no test commands specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fbbb10990832c884743016788286f