### PR TITLE
Add offline stats database

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -41,23 +41,21 @@ describe('metrics utilities', () => {
 });
 
 describe('similarity search', () => {
-  test('fetchPlayerAndSimilar selects the closest player', async () => {
+  test('fetchPlayerAndSimilar selects the closest player from local db', async () => {
     document.body.innerHTML = '<input id="year" value="2023"><div id="playerStats"></div>';
-    const responses = {
-      'https://statsapi.mlb.com/api/v1/people/1': { people: [{ primaryPosition: { abbreviation: 'P' }, fullName: 'Pitcher One' }] },
-      'https://statsapi.mlb.com/api/v1/people/1/stats?stats=season&group=pitching&season=2023': {
-        stats: [{ splits: [{ stat: { era: '3.00', battersFaced: '100', baseOnBalls: '10', strikeOuts: '20', war: '2' } }] }]
+    const db = {
+      pitching: {
+        '2023': [
+          { id: 1, name: 'Pitcher One', stat: { era: '3.00', battersFaced: '100', baseOnBalls: '10', strikeOuts: '20', war: '2' } }
+        ],
+        '2022': [
+          { id: 2, name: 'Pitcher Two', stat: { era: '3.05', battersFaced: '100', baseOnBalls: '11', strikeOuts: '21', war: '1.9' } }
+        ]
       },
-      'https://statsapi.mlb.com/api/v1/stats?stats=season&group=pitching&season=2022&playerPool=qualified&limit=300': {
-        stats: [{ splits: [{ player: { id: 2, fullName: 'Pitcher Two' }, stat: { era: '3.05', battersFaced: '100', baseOnBalls: '11', strikeOuts: '21', war: '1.9' } }] }]
-      }
+      hitting: {}
     };
-    const fetchMock = jest.fn(async url => {
-      const data = responses[url] || { stats: [{ splits: [] }] };
-      return { json: async () => data };
-    });
 
-    await fetchPlayerAndSimilar(1, fetchMock);
+    await fetchPlayerAndSimilar(1, () => Promise.resolve(), db);
     expect(document.getElementById('playerStats').innerHTML).toContain('Pitcher Two (2022)');
   });
 });

--- a/statsDatabase.json
+++ b/statsDatabase.json
@@ -1,0 +1,62 @@
+{
+  "hitting": {
+    "2023": [
+      {
+        "id": 10,
+        "name": "Hitter One",
+        "stat": {
+          "avg": "0.280",
+          "obp": "0.350",
+          "ops": "0.800",
+          "plateAppearances": "100",
+          "baseOnBalls": "10",
+          "strikeOuts": "20",
+          "war": "3.2"
+        }
+      }
+    ],
+    "2022": [
+      {
+        "id": 20,
+        "name": "Hitter Two",
+        "stat": {
+          "avg": "0.285",
+          "obp": "0.355",
+          "ops": "0.810",
+          "plateAppearances": "100",
+          "baseOnBalls": "9",
+          "strikeOuts": "19",
+          "war": "3.1"
+        }
+      }
+    ]
+  },
+  "pitching": {
+    "2023": [
+      {
+        "id": 1,
+        "name": "Pitcher One",
+        "stat": {
+          "era": "3.00",
+          "battersFaced": "100",
+          "baseOnBalls": "10",
+          "strikeOuts": "20",
+          "war": "2"
+        }
+      }
+    ],
+    "2022": [
+      {
+        "id": 2,
+        "name": "Pitcher Two",
+        "stat": {
+          "era": "3.05",
+          "battersFaced": "100",
+          "baseOnBalls": "11",
+          "strikeOuts": "21",
+          "war": "1.9"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- load stats from `statsDatabase.json` at startup
- update `fetchPlayerAndSimilar` to use local data when available
- adjust tests to use an in-memory stats DB
- provide a sample `statsDatabase.json`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840eb3884ac832cb6b29daf19fc5b9c